### PR TITLE
Fix oauth deprecation warnings

### DIFF
--- a/config/initializers/twitter.rb
+++ b/config/initializers/twitter.rb
@@ -1,6 +1,6 @@
 client = Twitter::REST::Client.new do |config|
   config.consumer_key = '8rqFySl0hIcwPHka7LEww'
   config.consumer_secret = '13djLnrNVrCnHfGyfgJqdzNxKqjqM9abI1Q5JZaM'
-  config.oauth_token = '17239142-za2x9GdzAJuumWhHN76aqEqTqFseKhH9Q5M8Kz14A'
-  config.oauth_token_secret = 'cRzE9PCkAoUzl0swVnXQVZ9k9iVJhSqVRWhMXofbM'
+  config.access_token = '17239142-za2x9GdzAJuumWhHN76aqEqTqFseKhH9Q5M8Kz14A'
+  config.access_token_secret = 'cRzE9PCkAoUzl0swVnXQVZ9k9iVJhSqVRWhMXofbM'
 end


### PR DESCRIPTION
This fixes these deprecation warnings:

    /home/nnyby/src/openvault/config/initializers/twitter.rb:4:in `block in <top (required)>': [DEPRECATION] #oauth_token= is deprecated. Use #access_token= instead.
    /home/nnyby/src/openvault/config/initializers/twitter.rb:5:in `block in <top (required)>': [DEPRECATION] #oauth_token_secret= is deprecated. Use #access_token_secret= instead.